### PR TITLE
DOC: added install instructions for python 2.7 (Mac)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose pandas statsmodels coverage
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib nose pandas statsmodels coverage
 
 # command to install dependencies
 install:
@@ -39,6 +39,7 @@ install:
   - pip install coveralls
   - pip install pysat
   - "python setup.py develop"
+  - pip install netCDF4
 # command to run tests
 script: 
   #- nosetests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pysatCDF
-[![Build Status](https://travis-ci.org/rstoneback/pysatCDF.svg?branch=master)](https://travis-ci.org/rstoneback/pysatCDF)
-[![Coverage Status](https://coveralls.io/repos/github/rstoneback/pysatCDF/badge.svg?branch=master)](https://coveralls.io/github/rstoneback/pysatCDF?branch=master)
+[![Build Status](https://travis-ci.org/pysat/pysatCDF.svg?branch=master)](https://travis-ci.org/pysat/pysatCDF)
+[![Coverage Status](https://coveralls.io/repos/github/pysat/pysatCDF/badge.svg?branch=master)](https://coveralls.io/github/pysat/pysatCDF?branch=master)
 [![DOI](https://zenodo.org/badge/51764432.svg)](https://zenodo.org/badge/latestdoi/51764432)
 
 Self-contained Python reader for NASA CDF file format

--- a/README.md
+++ b/README.md
@@ -89,3 +89,25 @@ Put the following in the file before saving and closing it.
 		python setup.py install
 This should compile and install the package to your site-packages for the python you are using.
 15. You should now be able to import pysatCDF in your Python environment. If you get an ImportError, restart Python and import again.
+
+# Installing PysatCDF for python 2.7 (Mac OS)
+
+The following has been tested on `10.13.6` and should work on `10.12.6`.
+
+We recommend the gcc compiler suite from anaconda. To set up a conda environment suitable for installation:
+
+```console
+conda create -n pysatCDF python=2.7
+conda install -c anaconda gcc
+conda install -c anaconda numpy
+pip install pysat (or setup.py after cloning pysat)
+```
+
+Install from the repo
+
+```console
+git clone https://github.com/pysat/pysatCDF.git
+cd pysatCDF
+python setup.py install (or pip install .)
+```
+


### PR DESCRIPTION
Addresses #15 

This should allow users to more easily install through anaconda for python 2.7 environments on mac. Let me know if I should update the conda build recipe as well.