### PR TITLE
Update style - import from pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
+jobs:
+  include:
+    - python: 2.7
+    - python: 3.6
+    - python: 3.7
+    - python: 3.8
 sudo: false
 
 
@@ -41,7 +43,7 @@ install:
   - "python setup.py develop"
   - pip install netCDF4
 # command to run tests
-script: 
+script:
   #- nosetests
   - nosetests  --with-coverage --cover-package=pysatCDF
   #coverage run --source=pysat setup.py test

--- a/setup.py
+++ b/setup.py
@@ -239,5 +239,5 @@ numpy.distutils.core.setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
-    install_requires=['numpy'],
+    install_requires=['numpy', 'pandas'],
 )


### PR DESCRIPTION
Addresses #21.  Updates pysatCDF to be consistent with pysat/pysat#369.  

With pysat 3.0.0, the convenience methods imported from pandas will be removed.  pysatCDF needs to be b updated so that it no longer imports `DataFrame`, etc, from pysat but from pandas.

Also updates python versions in Travis CI testing.