### PR TITLE
Enable building extension on gfortran>=8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,7 @@ ext1 = numpy.distutils.core.Extension(
     include_dirs=[f2py_cdf_include_path],
     f2py_options=['--quiet', '--include-paths', f2py_cdf_include_path],  # '--Wall', 'n', '--Wno-tabs', 'n'],
     extra_objects=[f2py_cdf_lib_path],
+    extra_f77_compile_args=['--std=legacy'],
     extra_link_args=extra_link_args)
 
 


### PR DESCRIPTION
Implements solution 2 on #30.

## Testing

1. Install gfortran >=8
2. `pip install git+https://github.com/pysat/pysatCDF.git@develop`

This fails as expected. Then try:

    pip install git+https://github.com/asreimer/pysatCDF.git@develop

which will succeed.